### PR TITLE
docs: enrich awsjs README with behavior, exports, and observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,79 @@
 
 Clients and tools for building on AWS.
 
-## Description
+`@pureskillgg/awsjs` is a shared Node.js library of thin, opinionated wrappers around the [AWS SDK for JavaScript v3]. It gives every PureSkill.gg Node service one uniform, camelCase interface for S3, DynamoDB, SQS, Lambda, EventBridge, and EventBridge Scheduler — with automatic request-id threading, gzip/JSON helpers, and structured [Pino] logging baked in.
 
-- Convenient wrappers around select methods from the [AWS SDK for JavaScript v3].
-- Method parameters normalized to accept camel case.
-- Standardized passing and parsing of request id (`reqId`).
-- Standardized structured logging using [Pino] via [mlabs-logger].
+## What it does
 
-[AWS SDK for JavaScript v3]: https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html
-[Pino]: https://getpino.io/
-[mlabs-logger]: https://github.com/meltwater/mlabs-logger/
+The package exports six client classes (re-exported through `index.js` → `lib/index.js` → `lib/clients/index.js`). Each class wraps exactly one AWS SDK v3 client and is constructed with a resource binding (a bucket, a `tableName`/`hashKey`/`rangeKey`, a `queueUrl`, a `functionName`, an `eventBusName`, or a scheduler `groupName`) plus an optional `reqId` (defaults to a UUID v4), a Pino child logger, and any SDK params.
+
+Every method follows the same shape:
+
+1. Build a child logger tagged with `client` / `class` / `method` / `reqId` and the resource binding.
+2. Log `start`.
+3. PascalCase the request keys (`keysToPascalCase`, via [@pureskillgg/phi]'s `renameKeysWith` + `change-case`) and inject the resource binding.
+4. Send the AWS command.
+5. camelCase the response (`keysToCamelCase`).
+6. Log `end` (or `error` / `fail` with the error) and return the normalized data.
+
+The result is a consistent camelCase API, automatic `reqId` propagation, and uniform structured logs across every AWS call in the platform.
+
+Notable per-client behavior:
+
+- **`S3Client`** — `putObjectJson` / `getObjectJson` serialize/deserialize JSON, set `ContentType: application/json`, transparently gzip/gunzip when `ContentEncoding` is `gzip` (detected by `isGzipped`, which splits the header on `,`, trims the first token, and checks it equals `gzip`), and stamp a `req-id` object **Metadata** header. `getObjectJson` returns both the raw body buffer and the parsed data.
+- **`DynamodbDocumentClient`** — wraps the DynamoDB Document client (`get` / `put` / `update` / `delete` / `query` / `transactGet` / `transactWrite`) with marshall options (remove undefined, convert class instances to map, no number wrapping). It validates at construction that `hashKey` is a non-empty string and that `rangeKey`, if present, is a non-empty string, and throws `DynamodbMissingKeyError` (`err_dynamodb_missing_key`) when input is missing the configured keys. `get` / `query` return `[data, rest]` tuples. It also exposes the raw `this.db` client and `this.tableName` as public escape hatches.
+- **`LambdaClient`** — `invokeJson` `Buffer`-encodes a JSON payload (injecting `reqId`), checks the HTTP `StatusCode` is 2xx (else `LambdaStatusCodeError`, `err_lambda_status_code`) and that there is no `FunctionError` (else `LambdaFunctionError`, `err_lambda_function_error`, carrying the decoded error payload), then decodes the JSON response payload.
+- **`SqsClient`** — `sendMessageJson` JSON-stringifies the body and attaches a `reqId` **String** message attribute (note: the attribute key is literally `reqId`, distinct from S3's `req-id` metadata key).
+- **`EventbridgeClient`** — `putEvents` stamps `EventBusName` on each entry, JSON-stringifies `detail`, normalizes the `time` field through [@pureskillgg/tau] (`fromIsoUtc` → `toIso`), drops nil fields, and throws `EventbridgeFailedEntriesError` (`err_eventbridge_failed_entries`) if `FailedEntryCount` is nonzero.
+- **`SchedulerClient`** — `getSchedule` / `createSchedule` / `updateSchedule` / `deleteSchedule` do CRUD on EventBridge Scheduler schedules with deep PascalCase/camelCase conversion of the nested `Target` object. The schedule-group `groupName` defaults to `default`.
+
+A small `createCache` helper (`lib/cache.js`) memoizes the underlying AWS SDK client instance per logical name so the raw client is reused across class instances within a process. ⚠️ See [Documentation](#documentation) — this caching has a footgun.
+
+## Pipeline role
+
+This is foundational infrastructure code, **not** a pipeline stage. It is published to npm as `@pureskillgg/awsjs` and imported by the platform's Node.js services (lambdas, handlers, web/API backends) wherever they need to talk to AWS — for example it is consumed by `csgo-profile` and other services.
+
+It sits *underneath* the CS2 coaching pipeline: any Node service that reads/writes match, demo, replay/csds, or assessment data in S3/DynamoDB, sends SQS messages, invokes lambdas, emits EventBridge events, or manages EventBridge schedules does so through these clients. The library itself produces no domain data and owns no cloud resources; the consuming service supplies the concrete bucket / table / queue / function identity at construction time.
+
+It consumes only the AWS SDK and sibling PSGG libraries: [@pureskillgg/phi] (FP / key-rename utilities), [@pureskillgg/tau] (ISO time), and [@pureskillgg/mlabs-logger] (logging).
+
+## Exported clients and helpers
+
+This library ships **no deployed AWS infrastructure** — there is no `serverless.yml`, no Terraform, no CDK, and no SAM template. It never hardcodes a table, queue, bucket, or function name; the consuming service passes the resource binding into the constructor. The real exports are:
+
+| Export | Source | Wraps / does |
+| --- | --- | --- |
+| `S3Client` | `lib/clients/s3.js` | `putObjectJson` / `getObjectJson` — JSON (de)serialization to/from S3 with transparent gzip/gunzip and a `req-id` metadata header. |
+| `DynamodbDocumentClient` | `lib/clients/dynamodb-document.js` | `get` / `put` / `update` / `delete` / `query` / `transactGet` / `transactWrite` over the DynamoDB Document client; key validation; `[data, rest]` tuples; throws `DynamodbMissingKeyError`. |
+| `LambdaClient` | `lib/clients/lambda.js` | `invokeJson` — `Buffer`-encoded JSON invoke with `reqId` injection; throws `LambdaStatusCodeError` / `LambdaFunctionError` on bad status or function error. |
+| `SqsClient` | `lib/clients/sqs.js` | `sendMessageJson` — JSON message body plus a `reqId` String message attribute. |
+| `EventbridgeClient` | `lib/clients/eventbridge.js` | `putEvents` — batch event publishing with `detail` JSON-encoding, ISO time normalization, and `FailedEntryCount` checking (`EventbridgeFailedEntriesError`). |
+| `SchedulerClient` | `lib/clients/scheduler.js` | `getSchedule` / `createSchedule` / `updateSchedule` / `deleteSchedule` — EventBridge Scheduler CRUD with nested `Target` case conversion. |
+| `keysToCamelCase` / `keysToPascalCase` | `lib/case.js` | Request/response key-case normalization used by every client (phi `renameKeysWith` + `change-case`). |
+| `createCache` | `lib/cache.js` | Memoizes underlying AWS SDK client instances per logical name to reuse connections. |
+
+### Error codes
+
+All client errors carry a stable `code` string for `instanceof`-free matching:
+
+- `err_dynamodb_missing_key` — `DynamodbMissingKeyError`
+- `err_lambda_status_code` — `LambdaStatusCodeError`
+- `err_lambda_function_error` — `LambdaFunctionError`
+- `err_eventbridge_failed_entries` — `EventbridgeFailedEntriesError`
+
+## Logs and observability
+
+This is a **pure published npm library** — it owns no CloudWatch log groups, DLQs, Step Functions, Sentry projects, or EventBridge buses. There is nothing in this repo to look up in CloudWatch.
+
+- **Where its logs actually appear:** in the **consuming service's** logs. The library logs through [@pureskillgg/mlabs-logger] (Pino), created with `createLogger()` and child-scoped with `{ client, class, method, reqId, queueUrl/bucket/table, messageId }`. So to find a given AWS call, look at the log group of whatever lambda/service imported the client (e.g. `csgo-*-prod-*`), filtered by `reqId`.
+- **Normal logs:** `start` and `end` events at `info`; payloads at `debug`.
+- **Error logs:** each client method wraps the SDK call in `try`/`catch`, logs `log.error({ err }, 'fail')`, and re-throws. The error then propagates to the caller, where the caller's own infrastructure (Lambda DLQ, Step Functions state, Sentry) is where it ultimately lands.
+- **Verbosity:** standard Pino `LOG_LEVEL` / `level` env behavior applies in the consuming process.
+- **CI logs for this repo:** build/test output lives in this repo's [GitHub Actions], not in AWS.
+
+## Documentation
+
+- [Client caching, key-case, and error conventions](docs/conventions.md) — the shared-client memoization footgun in `createCache`, the PascalCase-in / camelCase-out request lifecycle, and the per-client error-code contract.
 
 ## Installation
 
@@ -158,3 +221,10 @@ loss of use, data, or profits; or business interruption) however caused and on
 any theory of liability, whether in contract, strict liability, or tort
 (including negligence or otherwise) arising in any way out of the use of this
 software, even if advised of the possibility of such damage.
+
+[AWS SDK for JavaScript v3]: https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html
+[Pino]: https://getpino.io/
+[@pureskillgg/phi]: https://github.com/pureskillgg/phi
+[@pureskillgg/tau]: https://github.com/pureskillgg/tau
+[@pureskillgg/mlabs-logger]: https://github.com/pureskillgg/mlabs-logger
+[mlabs-logger]: https://github.com/meltwater/mlabs-logger/

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,50 @@
+# Client caching, key-case, and error conventions
+
+This companion explains three behaviors of `@pureskillgg/awsjs` that are not obvious from the method signatures and that bite consumers in practice.
+
+## 1. Shared-client memoization (the `createCache` footgun)
+
+`lib/cache.js` exposes `createCache`, which each client module calls **once at module scope**. The cache memoizes the underlying AWS SDK v3 client instance keyed on a logical `name` (e.g. `s3`, `sqs`, `dynamodb`). Because the cache lives at module scope, the raw SDK client is shared across **all instances** of that class within a single Node process whenever they share the same `name`.
+
+Consequences:
+
+- **The first constructor wins.** The first time a class is instantiated, its SDK params (region, endpoint, credentials, etc.) build the underlying client. Later instances with the *same* `name` but *different* params silently reuse that first client — their params are ignored.
+- The `namespace` argument to `createCache` is currently **unused**; memoization is keyed purely on the second-level `name`.
+- This is a connection-reuse optimization (good for Lambda warm starts), but it means you cannot have two `S3Client` instances in one process pointed at, say, two different regions via SDK params. Override the resource *binding* (bucket/table/queue) per call all you like — that is per-instance — but the SDK client config is process-global per `name`.
+
+If you genuinely need a differently-configured SDK client, construct the raw AWS SDK client yourself and pass it in (or use the public escape hatches such as `DynamodbDocumentClient.db`).
+
+## 2. Request lifecycle: PascalCase in, camelCase out
+
+Every method runs the same pipeline (see `lib/case.js`):
+
+1. **Request keys → PascalCase.** `keysToPascalCase` (phi `renameKeysWith` + `change-case`) converts your camelCase params to the PascalCase the AWS SDK expects. So you call `getObject({ key })` and the library sends `{ Key }`.
+2. **Resource binding injected.** The constructor binding (`Bucket`, `TableName`, `QueueUrl`, `FunctionName`, `EventBusName`, schedule `GroupName`) is merged in so you never repeat it per call.
+3. **Command sent** to the wrapped SDK client.
+4. **Response keys → camelCase.** `keysToCamelCase` converts the SDK's PascalCase response back to camelCase for you.
+
+Two return-shape conventions to know:
+
+- `DynamodbDocumentClient.get` and `.query` return a `[data, rest]` tuple — `data` is the item/items, `rest` is the remaining response metadata.
+- `S3Client.getObjectJson` returns both the raw body buffer and the parsed `data`.
+
+Key-naming gotcha: S3 stamps the request id as object **Metadata** under the key `req-id`, while SQS attaches it as a **MessageAttribute** under the key `reqId`. Same value, different key — do not conflate them when grepping logs or reading raw records.
+
+### gzip detection
+
+`S3Client` gzips/gunzips transparently when `ContentEncoding` is `gzip`. Detection (`isGzipped`) splits the header on `,`, trims the first token, and checks it equals `gzip` — so `gzip, identity` is correctly treated as gzipped.
+
+## 3. Error-code contract
+
+Each client throws a typed error carrying a stable `code` string, so callers can branch without `instanceof` across module boundaries:
+
+| Error | `code` | Thrown when |
+| --- | --- | --- |
+| `DynamodbMissingKeyError` | `err_dynamodb_missing_key` | input is missing a configured `hashKey`/`rangeKey` |
+| `LambdaStatusCodeError` | `err_lambda_status_code` | invoke `StatusCode` is not 2xx (check is `> 199 && < 300`) |
+| `LambdaFunctionError` | `err_lambda_function_error` | the invoked function returned a `FunctionError`; carries the decoded error payload |
+| `EventbridgeFailedEntriesError` | `err_eventbridge_failed_entries` | `FailedEntryCount` is nonzero |
+
+Edge case worth noting: the EventBridge check is a strict `if (FailedEntryCount === 0) return`. A missing/`undefined` `FailedEntryCount` would *not* short-circuit and would fall through to throwing — so treat an unexpected response shape as a failure, not a success.
+
+All four errors are also logged via `log.error({ err }, 'fail')` before being re-thrown, so they appear in the consuming service's structured logs scoped by `reqId`.


### PR DESCRIPTION
## Summary

Rewrites the thin top description of the `@pureskillgg/awsjs` README into an informative overview, and adds a focused deep-dive doc, while keeping all existing boilerplate verbatim.

### README changes
- Replaces the one-line `Description` bullet list with:
  - A one-line summary of what the library is.
  - A **What it does** section documenting the shared method lifecycle (PascalCase-in / camelCase-out, `reqId` threading, structured logging) and the notable per-client behavior for all six clients.
  - A **Pipeline role** section: foundational infra published to npm, consumed by Node services (e.g. `csgo-profile`), sitting underneath the CS2 coaching pipeline; depends on `@pureskillgg/phi`, `@pureskillgg/tau`, `@pureskillgg/mlabs-logger`.
- Adds an **Exported clients and helpers** table listing the six client classes plus `keysToCamelCase`/`keysToPascalCase` and `createCache` by their real source paths, and an error-code list.
- Adds a **Logs and observability** section clarifying this is a pure library — no CloudWatch/DLQ/Sentry of its own; logs surface in the consuming service's log group, scoped by `reqId`.
- Adds a **Documentation** section linking the new deep-dive.

### New docs
- `docs/conventions.md` — the `createCache` shared-client memoization footgun, the request-case lifecycle (incl. gzip detection and the `req-id` vs `reqId` key distinction), and the per-client error-code contract.

### Preserved verbatim
Installation, Development and Testing, Requirements, Publishing, GitHub Actions secrets, Contributing, License, and Warranty are unchanged. Badges retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)