### PR TITLE
Fix EventbridgeClient: send PutEvents Time as a Date (SDK v3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 3.0.3
+
+### Fixed
+
+- `EventbridgeClient.putEvents`: send the entry `Time` as a `Date` rather than an
+  ISO string. Under AWS SDK v3, `PutEventsCommand` rejects a string timestamp
+  with `SerializationException: STRING_VALUE can not be converted to milliseconds
+  since epoch`, so any event carrying a `time` failed since the v3 upgrade.
+
 ## 3.0.0
 
 ### Changed

--- a/lib/clients/eventbridge.js
+++ b/lib/clients/eventbridge.js
@@ -110,7 +110,8 @@ const formatEventInput = (eventBusName) =>
     filter(reject(isNil)),
     evolve({
       detail: toJson,
-      time: compose(toIso, fromIsoUtc)
+      // SDK v3 PutEvents needs a real Date; an ISO string throws SerializationException.
+      time: compose((iso) => new Date(iso), toIso, fromIsoUtc)
     }),
     keysToPascalCase
   )

--- a/lib/clients/eventbridge.spec.js
+++ b/lib/clients/eventbridge.spec.js
@@ -142,7 +142,7 @@ const eventInput = [
 ]
 
 const eventEntry = {
-  Time: '2020-01-01T00:00:00.000Z',
+  Time: new Date('2020-01-01T00:00:00.000Z'),
   Source: 'mock-source',
   Resources: ['mock-resource'],
   DetailType: 'mock-detail-type',


### PR DESCRIPTION
## Problem

`EventbridgeClient.putEvents` sends the entry `Time` as an ISO string. Under AWS SDK v3, `PutEventsCommand` rejects that with:

```
SerializationException: STRING_VALUE can not be converted to milliseconds since epoch  (HTTP 400)
```

`formatEventInput` normalized the event's `time` to an ISO string and passed it straight through:

```js
evolve({
  detail: toJson,
  time: compose(toIso, fromIsoUtc)   // <- ISO string
})
```

SDK v2 tolerated a timestamp string; v3 requires a real `Date`. This is the same class of bug that broke blobd's `eventbridge-put-events` handler after its v3 migration (fixed there in 3.1.0).

**Impact:** latent today — no current caller passes a top-level `time` (event emitters use `{ detail, detailType, source }`), so EventBridge defaults `Time` to ingestion time. But the moment any event carries a `time`, it fails. This removes the landmine.

## Fix

Wrap the normalized value in a `Date` so the SDK marshals it correctly:

```js
time: compose((iso) => new Date(iso), toIso, fromIsoUtc)
```

Normalization via `fromIsoUtc`/`toIso` is preserved; only the final type handed to the SDK changes (string → `Date`).

## Validation

- `npx ava lib/clients/eventbridge.spec.js` → **6/6 pass** (spec updated to expect `Time: new Date(...)`).
- Prettier: content-clean (the local `--check` warning is the repo's known CRLF-vs-LF false positive; CI runs on LF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
