### PR TITLE
docs: fill in missing changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   with `SerializationException: STRING_VALUE can not be converted to milliseconds
   since epoch`, so any event carrying a `time` failed since the v3 upgrade.
 
+## 3.0.2
+
+### Changed
+
+- Bump the runtime dependencies to their current majors.
+- Modernize the development toolchain (ESLint 9 flat config).
+
+## 3.0.1
+
+- Version bump; no functional changes.
+
 ## 3.0.0
 
 ### Changed


### PR DESCRIPTION
Backfills and reconciles `CHANGELOG.md` for releases from the last ~30 days that shipped without changelog updates.

- Adds headings for released versions that had no entry.
- Where a heading's version number was *ahead* of the latest actual release (an anticipated bump that shipped under a different number), relabels it to the version it actually shipped in — no published version is renumbered.
- Only `CHANGELOG.md` is touched.

Part of a cross-repo changelog audit.